### PR TITLE
feat: #33 Order Dto 와 PaymentRequestDto 생성

### DIFF
--- a/src/main/java/com/sparta/dingdong/domain/order/dto/OrderStatusHistoryDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/OrderStatusHistoryDto.java
@@ -1,0 +1,22 @@
+package com.sparta.dingdong.domain.order.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderStatusHistoryDto {
+	private final UUID historyId;
+	private final UUID orderId;
+	private final String prevStatus;
+	private final String newStatus;
+	private final Long changedBy;
+	private final String changedByName;
+	private final LocalDateTime changedAt;
+	private final String reasonDetail;
+	private final LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/dto/request/OrderCancelRequestDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/request/OrderCancelRequestDto.java
@@ -1,0 +1,13 @@
+package com.sparta.dingdong.domain.order.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderCancelRequestDto {
+	@NotBlank
+	private final String cancelReason;
+
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/dto/request/OrderRequestDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/request/OrderRequestDto.java
@@ -1,0 +1,23 @@
+package com.sparta.dingdong.domain.order.dto.request;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderRequestDto {
+
+	@NotNull
+	private final UUID cartId;
+
+	@NotBlank
+	private final String deliveryAddress;
+
+	@NotBlank
+	private final String paymentMethod;
+
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/dto/request/OrderStatusUpdateRequestDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/request/OrderStatusUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.sparta.dingdong.domain.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderStatusUpdateRequestDto {
+
+	@NotNull
+	private final String status;
+
+	private final String cancelReason;
+
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/dto/response/CustomerOrderResponseDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/response/CustomerOrderResponseDto.java
@@ -1,0 +1,25 @@
+package com.sparta.dingdong.domain.order.dto.response;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CustomerOrderResponseDto {
+	private final UUID orderId;
+	private final UUID storeId;
+	private final String storeName;
+	private final String orderStatus;
+	private final BigInteger totalPrice;
+	private final String paymentStatus;
+	private final LocalDateTime placedAt;
+	private final LocalDateTime deliveredAt;
+	private final String deliveryAddress;
+	private final List<OrderItemResponseDto> items;
+	private final String cancelReason;
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/dto/response/MasterOrderResponseDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/response/MasterOrderResponseDto.java
@@ -1,0 +1,33 @@
+package com.sparta.dingdong.domain.order.dto.response;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MasterOrderResponseDto {
+	private final UUID orderId;
+	private final UUID storeId;
+	private final String storeName;
+	private final String orderStatus;
+	private final BigInteger totalPrice;
+	private final String paymentStatus;
+	private final String paymentTxId; // 결제 ID
+	private final String refundTxId; // 환불 ID
+	private final BigInteger refundAmount;
+	private final LocalDateTime placedAt;
+	private final LocalDateTime deliveredAt;
+	private final String deliveryAddress;
+	private final List<OrderItemResponseDto> items;
+	private final String cancelReason;
+	private final String customerName;
+	private final String customerPhone;
+	private final Long createdBy;
+	private final String createdByName;
+	private final Long updatedBy;
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/dto/response/OrderItemResponseDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/response/OrderItemResponseDto.java
@@ -1,0 +1,18 @@
+package com.sparta.dingdong.domain.order.dto.response;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderItemResponseDto {
+	private final UUID itemId;
+	private final UUID menuItemId;
+	private final String menuName;
+	private final BigInteger unitPrice;
+	private final int quantity;
+	private final BigInteger totalPrice;
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/dto/response/OrderStatusUpdateResponseDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/response/OrderStatusUpdateResponseDto.java
@@ -1,0 +1,15 @@
+package com.sparta.dingdong.domain.order.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderStatusUpdateResponseDto {
+	private final UUID orderId;
+	private final String orderStatus;
+	private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/dto/response/OwnerOrderResponseDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/dto/response/OwnerOrderResponseDto.java
@@ -1,0 +1,27 @@
+package com.sparta.dingdong.domain.order.dto.response;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OwnerOrderResponseDto {
+	private final UUID orderId;
+	private final UUID storeId;
+	private final String storeName;
+	private final String orderStatus;
+	private final BigInteger totalPrice;
+	private final String paymentStatus;
+	private final LocalDateTime placedAt;
+	private final LocalDateTime deliveredAt;
+	private final String deliveryAddress;
+	private final List<OrderItemResponseDto> items;
+	private final String cancelReason;
+	private final String customerName;
+	private final String customerPhone;
+}

--- a/src/main/java/com/sparta/dingdong/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/entity/Order.java
@@ -62,6 +62,9 @@ public class Order extends BaseEntity {
 	private LocalDateTime deliveredAt;
 	private LocalDateTime canceledAt;
 
+	@Column
+	private String cancelReason;
+
 	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<OrderItem> orderItems = new ArrayList<>();
 

--- a/src/main/java/com/sparta/dingdong/domain/order/entity/OrderStatusHistory.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/entity/OrderStatusHistory.java
@@ -34,8 +34,11 @@ public class OrderStatusHistory extends BaseEntity {
 	private Order order;
 
 	@Enumerated(EnumType.STRING)
+	private OrderStatus preStatus;
+
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private OrderStatus status;
+	private OrderStatus newStatus;
 
 	@Column(nullable = false)
 	private Long changedBy;

--- a/src/main/java/com/sparta/dingdong/domain/payment/dto/request/PaymentRequestDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/payment/dto/request/PaymentRequestDto.java
@@ -1,0 +1,22 @@
+package com.sparta.dingdong.domain.payment.dto.request;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentRequestDto {
+	@NotNull
+	private final UUID orderId;
+
+	@NotNull
+	private final BigInteger amount;
+
+	@NotBlank
+	private final String paymentMethod;
+}


### PR DESCRIPTION
## 🔗 Issue 번호
- close #33 

## 🛠 작업 내역
- Order Dto 생성
- OrderResponseDto : customer, owner, master 나눔


## 🔄 변경 사항
 - `p_order`
    - 주문 취소 하는 경우 주문취소사유 (cancel_reason) 필드 추가
- `p_order_status_history`
    - 변경 전 상태 정보 (pre_status) 필드 추가
    - 기존 status 필드 → new_status 로 변경

## ✨ 새로운 기능
### DTO 생성

**Request**

- OrderCancelRequestDto : customer 취소 요청 정보
- OrderRequestDto : 주문 생성 요청 정보
- OrderStatusUpdateRequestDto : owner,master 주문 상태 변경 요청 정보

**Response**

- CustomerOrderResponseDto : customer에게 보여줄 주문 전체 정보 (주문 상세 페이지와 목록)
- MasterOrderResponseDto : master에게 보여줄 주문 전체 정보
- OrderItemResponseDto : 메뉴별 정보
- OrderStatusUpdateResponseDto : 주문 상태 변경 정보
- OwnerOrderResponseDto : owner에게 보여줄 주문 전체 정보

- OrderStatusHistoryDto : master에게 보여줄 주문 히스토리 정보, 내부 서비스 레이어에서 데이터 가공


## 📦 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

