### PR TITLE
Refactor cart & TestCode 

### DIFF
--- a/src/main/java/com/sparta/dingdong/domain/cart/controller/CartControllerV1.java
+++ b/src/main/java/com/sparta/dingdong/domain/cart/controller/CartControllerV1.java
@@ -70,19 +70,19 @@ public class CartControllerV1 {
 	@Operation(summary = "장바구니에 담긴 메뉴 삭제 API", description = "장바구니에 담긴 메뉴를 삭제합니다.")
 	@PreAuthorize("hasRole('ROLE_CUSTOMER')")
 	@DeleteMapping("/items/{menuItemId}")
-	public ResponseEntity<BaseResponseDto<Void>> deleteItem(
+	public ResponseEntity<BaseResponseDto<Void>> deleteMenuItem(
 		@Parameter(description = "메뉴 아이템 UUID") @PathVariable UUID menuItemId,
 		@AuthenticationPrincipal UserAuth userAuth) {
-		cartService.removeItem(userAuth, menuItemId); // 명확한 remove 메서드 권장
+		cartService.deleteItem(userAuth, menuItemId); // 명확한 remove 메서드 권장
 		return ResponseEntity.ok(BaseResponseDto.success("장바구니에 담긴 메뉴가 삭제되었습니다."));
 	}
 
 	@Operation(summary = "장바구니 삭제 API", description = "장바구니를 삭제합니다.")
 	@PreAuthorize("hasRole('ROLE_CUSTOMER')")
 	@DeleteMapping
-	public ResponseEntity<BaseResponseDto<Void>> clearCart(
+	public ResponseEntity<BaseResponseDto<Void>> deleteCart(
 		@AuthenticationPrincipal UserAuth userAuth) {
-		cartService.clearCart(userAuth);
+		cartService.deleteCart(userAuth);
 		return ResponseEntity.ok(BaseResponseDto.success("장바구니가 삭제되었습니다."));
 	}
 }

--- a/src/main/java/com/sparta/dingdong/domain/cart/dto/response/CartResponseDto.java
+++ b/src/main/java/com/sparta/dingdong/domain/cart/dto/response/CartResponseDto.java
@@ -1,7 +1,6 @@
 package com.sparta.dingdong.domain.cart.dto.response;
 
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -39,11 +38,4 @@ public class CartResponseDto {
 			.build();
 	}
 
-	public static CartResponseDto empty() {
-		return CartResponseDto.builder()
-			.items(Collections.emptyList())
-			.totalPrice(BigInteger.ZERO)
-			.message("장바구니가 비어 있습니다.")
-			.build();
-	}
 }

--- a/src/main/java/com/sparta/dingdong/domain/cart/entity/Cart.java
+++ b/src/main/java/com/sparta/dingdong/domain/cart/entity/Cart.java
@@ -2,10 +2,10 @@ package com.sparta.dingdong.domain.cart.entity;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import com.sparta.dingdong.common.base.BaseEntity;
+import com.sparta.dingdong.domain.menu.entity.MenuItem;
 import com.sparta.dingdong.domain.store.entity.Store;
 import com.sparta.dingdong.domain.user.entity.User;
 
@@ -59,19 +59,24 @@ public class Cart extends BaseEntity {
 		return new Cart(user, store);
 	}
 
-	public void addItem(CartItem item) {
-		// 합산 로직: 같은 menuItem이면 수량 더하기
-		Optional<CartItem> existing = items.stream()
-			.filter(i -> i.getMenuItem().getId().equals(item.getMenuItem().getId()))
-			.findFirst();
-		if (existing.isPresent()) {
-			existing.get().increaseQuantity(item.getQuantity());
+	public void addItem(MenuItem menu, int quantity) {
+		CartItem existing = findExistingItem(menu.getId());
+		if (existing != null) {
+			existing.increaseQuantity(quantity);
 		} else {
+			CartItem item = CartItem.of(menu, quantity);
 			item.setCart(this);
 			items.add(item);
 		}
 	}
 
+	private CartItem findExistingItem(UUID menuItemId) {
+		return items.stream()
+			.filter(i -> i.getMenuItem().getId().equals(menuItemId))
+			.findFirst()
+			.orElse(null);
+	}
+	
 	public void setStore(Store store) {
 		this.store = store;
 	}

--- a/src/main/java/com/sparta/dingdong/domain/cart/entity/Cart.java
+++ b/src/main/java/com/sparta/dingdong/domain/cart/entity/Cart.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -39,8 +40,8 @@ public class Cart extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.UUID)
 	private UUID id;
 
-	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "user_id", nullable = false, updatable = false)
+	@OneToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false, unique = true)
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/sparta/dingdong/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/dingdong/domain/cart/service/CartService.java
@@ -1,25 +1,23 @@
 package com.sparta.dingdong.domain.cart.service;
 
+import java.util.UUID;
+
 import com.sparta.dingdong.common.jwt.UserAuth;
 import com.sparta.dingdong.domain.cart.dto.request.AddCartItemRequestDto;
 import com.sparta.dingdong.domain.cart.dto.response.CartResponseDto;
 import com.sparta.dingdong.domain.cart.entity.Cart;
 
-import java.util.UUID;
-
 public interface CartService {
 
-    CartResponseDto getCart(UserAuth userAuth);
+	Cart findByUserId(Long userId);
 
-    CartResponseDto addItem(UserAuth userAuth, AddCartItemRequestDto req, boolean replace);
+	CartResponseDto getCart(UserAuth userAuth);
 
-    CartResponseDto updateItemQuantity(UserAuth userAuth, UUID menuItemId, int quantity);
+	CartResponseDto addItem(UserAuth userAuth, AddCartItemRequestDto req, boolean replace);
 
-    void removeItem(UserAuth userAuth, UUID menuItemId);
+	CartResponseDto updateItemQuantity(UserAuth userAuth, UUID menuItemId, int quantity);
 
-    void clearCart(UserAuth userAuth);
+	void deleteItem(UserAuth userAuth, UUID menuItemId);
 
-    Cart findByCart(UUID cartId);
-
-    void deleteCart(Cart cart);
+	void deleteCart(UserAuth userAuth);
 }

--- a/src/main/java/com/sparta/dingdong/domain/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/sparta/dingdong/domain/cart/service/CartServiceImpl.java
@@ -18,7 +18,6 @@ import com.sparta.dingdong.domain.cart.repository.CartRepository;
 import com.sparta.dingdong.domain.menu.entity.MenuItem;
 import com.sparta.dingdong.domain.menu.exception.MenuItemSoldOutException;
 import com.sparta.dingdong.domain.menu.service.MenuItemService;
-import com.sparta.dingdong.domain.store.entity.Store;
 import com.sparta.dingdong.domain.user.entity.User;
 import com.sparta.dingdong.domain.user.service.UserService;
 
@@ -65,12 +64,8 @@ public class CartServiceImpl implements CartService {
 			throw new MenuItemSoldOutException();
 		}
 
-		Cart cart = cartRepository.findByUserId(user.getId()).orElse(null);
-
 		// 장바구니가 없는 경우 새 생성
-		if (cart == null) {
-			cart = createNewCartForUser(user, menu.getStore());
-		}
+		Cart cart = cartRepository.findByUserId(user.getId()).orElse(Cart.of(user, menu.getStore()));
 
 		// 장바구니가 있고 다른 가게인 경우
 		if (cart.getStore() != null && !cart.getStore().getId().equals(menu.getStore().getId())) {
@@ -86,11 +81,6 @@ public class CartServiceImpl implements CartService {
 		cart.addItem(menu, req.getQuantity());
 		Cart saved = cartRepository.save(cart);
 		return CartResponseDto.from(saved);
-	}
-
-	private Cart createNewCartForUser(User user, Store store) {
-		Cart newCart = Cart.of(user, store);
-		return cartRepository.save(newCart);
 	}
 
 	@Override

--- a/src/main/java/com/sparta/dingdong/domain/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/sparta/dingdong/domain/cart/service/CartServiceImpl.java
@@ -78,8 +78,8 @@ public class CartServiceImpl implements CartService {
 			}
 		}
 
-		// 카트에 아이템 합산 또는 신규 추가
-		cart.addItem(CartItem.of(menu, req.getQuantity()));
+		// 이미 존재하면 수량 합산, 없으면 새 아이템 추가
+		cart.addItem(menu, req.getQuantity());
 		Cart saved = cartRepository.save(cart);
 		return CartResponseDto.from(saved);
 	}

--- a/src/main/java/com/sparta/dingdong/domain/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/sparta/dingdong/domain/cart/service/CartServiceImpl.java
@@ -1,5 +1,10 @@
 package com.sparta.dingdong.domain.cart.service;
 
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.sparta.dingdong.common.jwt.UserAuth;
 import com.sparta.dingdong.domain.cart.dto.request.AddCartItemRequestDto;
 import com.sparta.dingdong.domain.cart.dto.response.CartResponseDto;
@@ -13,140 +18,124 @@ import com.sparta.dingdong.domain.cart.repository.CartRepository;
 import com.sparta.dingdong.domain.menu.entity.MenuItem;
 import com.sparta.dingdong.domain.menu.exception.MenuItemNotFoundException;
 import com.sparta.dingdong.domain.menu.exception.MenuItemSoldOutException;
-import com.sparta.dingdong.domain.menu.repository.MenuItemRepository;
+import com.sparta.dingdong.domain.menu.service.MenuItemService;
 import com.sparta.dingdong.domain.store.entity.Store;
 import com.sparta.dingdong.domain.user.entity.User;
 import com.sparta.dingdong.domain.user.service.UserService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class CartServiceImpl implements CartService {
 
-    private final CartRepository cartRepository;
-    private final MenuItemRepository menuItemRepository;
-    private final UserService userService;
+	private final CartRepository cartRepository;
+	private final MenuItemService menuItemService;
+	private final UserService userService;
 
-    @Override
-    @Transactional(readOnly = true)
-    public CartResponseDto getCart(UserAuth userAuth) {
-        User user = userService.findByUser(userAuth);
+	@Override
+	@Transactional(readOnly = true)
+	public Cart findByUserId(Long userId) {
+		return cartRepository.findByUserId(userId)
+			.orElseThrow(() -> new CartNotFoundException());
+	}
 
-        Cart cart = cartRepository.findByUserId(user.getId())
-                .orElseThrow(CartNotFoundException::new);
+	@Override
+	@Transactional(readOnly = true)
+	public CartResponseDto getCart(UserAuth userAuth) {
+		User user = userService.findByUser(userAuth);
+		Cart cart = findByUserId(user.getId());
 
-        return CartResponseDto.from(cart);
-    }
+		return CartResponseDto.from(cart);
+	}
 
-    @Override
-    @Transactional
-    public CartResponseDto addItem(UserAuth userAuth, AddCartItemRequestDto req, boolean replace) {
-        User user = userService.findByUser(userAuth);
+	@Override
+	@Transactional
+	public CartResponseDto addItem(UserAuth userAuth, AddCartItemRequestDto req, boolean replace) {
+		User user = userService.findByUser(userAuth);
 
-        MenuItem menu = menuItemRepository.findById(req.getMenuItemId())
-                .orElseThrow(MenuItemNotFoundException::new);
+		MenuItem menu = menuItemRepository.findById(req.getMenuItemId())
+			.orElseThrow(MenuItemNotFoundException::new);
 
-        if (menu.getIsSoldout()) {
-            throw new MenuItemSoldOutException();
-        }
+		if (menu.getIsSoldout()) {
+			throw new MenuItemSoldOutException();
+		}
 
-        Cart cart = cartRepository.findByUserId(user.getId()).orElse(null);
+		Cart cart = cartRepository.findByUserId(user.getId()).orElse(null);
 
-        // 장바구니가 없는 경우 새 생성
-        if (cart == null) {
-            cart = createNewCartForUser(user, menu.getStore());
-        }
+		// 장바구니가 없는 경우 새 생성
+		if (cart == null) {
+			cart = createNewCartForUser(user, menu.getStore());
+		}
 
-        // 장바구니가 있고 다른 가게인 경우
-        if (cart.getStore() != null && !cart.getStore().getId().equals(menu.getStore().getId())) {
-            if (replace) {
-                cart.clear();
-                cart.setStore(menu.getStore());
-            } else {
-                throw new CartStoreConflictException();
-            }
-        }
+		// 장바구니가 있고 다른 가게인 경우
+		if (cart.getStore() != null && !cart.getStore().getId().equals(menu.getStore().getId())) {
+			if (replace) {
+				cart.clear();
+				cart.setStore(menu.getStore());
+			} else {
+				throw new CartStoreConflictException();
+			}
+		}
 
-        // 카트에 아이템 합산 또는 신규 추가
-        cart.addItem(CartItem.of(menu, req.getQuantity()));
-        Cart saved = cartRepository.save(cart);
-        return CartResponseDto.from(saved);
-    }
+		// 카트에 아이템 합산 또는 신규 추가
+		cart.addItem(CartItem.of(menu, req.getQuantity()));
+		Cart saved = cartRepository.save(cart);
+		return CartResponseDto.from(saved);
+	}
 
-    private Cart createNewCartForUser(User user, Store store) {
-        Cart newCart = Cart.of(user, store);
-        return cartRepository.save(newCart);
-    }
+	private Cart createNewCartForUser(User user, Store store) {
+		Cart newCart = Cart.of(user, store);
+		return cartRepository.save(newCart);
+	}
 
-    @Override
-    @Transactional
-    public CartResponseDto updateItemQuantity(UserAuth userAuth, UUID menuItemId, int quantity) {
-        User user = userService.findByUser(userAuth);
+	@Override
+	@Transactional
+	public CartResponseDto updateItemQuantity(UserAuth userAuth, UUID menuItemId, int quantity) {
+		User user = userService.findByUser(userAuth);
+		Cart cart = findByUserId(user.getId());
 
-        Cart cart = cartRepository.findByUserId(user.getId())
-                .orElseThrow(CartNotFoundException::new);
+		CartItem item = cart.getItems().stream()
+			.filter(i -> i.getMenuItem().getId().equals(menuItemId))
+			.findFirst()
+			.orElseThrow(CartItemNotFoundException::new);
 
-        CartItem item = cart.getItems().stream()
-                .filter(i -> i.getMenuItem().getId().equals(menuItemId))
-                .findFirst()
-                .orElseThrow(CartItemNotFoundException::new);
+		if (quantity <= 0) {
+			throw new InvalidCartQuantityException();
+		} else {
+			item.updateQuantity(quantity);
+		}
 
-        if (quantity <= 0) {
-            throw new InvalidCartQuantityException();
-        } else {
-            item.updateQuantity(quantity);
-        }
+		Cart saved = cartRepository.save(cart);
+		return CartResponseDto.from(saved);
+	}
 
-        Cart saved = cartRepository.save(cart);
-        return CartResponseDto.from(saved);
-    }
+	@Override
+	@Transactional
+	public void deleteItem(UserAuth userAuth, UUID menuItemId) {
+		User user = userService.findByUser(userAuth);
+		Cart cart = findByUserId(user.getId());
 
-    @Override
-    @Transactional
-    public void removeItem(UserAuth userAuth, UUID menuItemId) {
-        User user = userService.findByUser(userAuth);
+		CartItem item = cart.getItems().stream()
+			.filter(i -> i.getMenuItem().getId().equals(menuItemId))
+			.findFirst()
+			.orElseThrow(CartItemNotFoundException::new);
 
-        Cart cart = cartRepository.findByUserId(user.getId())
-                .orElseThrow(CartNotFoundException::new);
+		cart.removeItem(item.getId());
+		if (cart.getItems().isEmpty()) { // 장바구니에 메뉴가 없으면 장바구니 삭제
+			cartRepository.delete(cart);
+		} else {
+			cartRepository.save(cart);
+		}
+	}
 
-        CartItem item = cart.getItems().stream()
-                .filter(i -> i.getMenuItem().getId().equals(menuItemId))
-                .findFirst()
-                .orElseThrow(CartItemNotFoundException::new);
+	@Override
+	@Transactional
+	public void deleteCart(UserAuth userAuth) {
+		User user = userService.findByUser(userAuth);
+		Cart cart = findByUserId(user.getId());
 
-        cart.removeItem(item.getId());
-        if (cart.getItems().isEmpty()) { // 장바구니에 메뉴가 없으면 장바구니 삭제
-            cartRepository.delete(cart);
-        } else {
-            cartRepository.save(cart);
-        }
-    }
-
-    @Override
-    @Transactional
-    public void clearCart(UserAuth userAuth) {
-        User user = userService.findByUser(userAuth);
-
-        Cart cart = cartRepository.findByUserId(user.getId())
-                .orElseThrow(CartNotFoundException::new);
-        cartRepository.delete(cart);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Cart findByCart(UUID cartId) {
-        return cartRepository.findById(cartId)
-                .orElseThrow(() -> new CartNotFoundException());
-    }
-
-    @Override
-    @Transactional
-    public void deleteCart(Cart cart) {
-        cartRepository.delete(cart);
-    }
+		cartRepository.delete(cart);
+	}
 
 }

--- a/src/main/java/com/sparta/dingdong/domain/menu/service/MenuItemService.java
+++ b/src/main/java/com/sparta/dingdong/domain/menu/service/MenuItemService.java
@@ -9,8 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.sparta.dingdong.common.jwt.UserAuth;
 import com.sparta.dingdong.domain.menu.dto.request.MenuItemRequestDto;
 import com.sparta.dingdong.domain.menu.dto.response.MenuItemResponseDto;
+import com.sparta.dingdong.domain.menu.entity.MenuItem;
 
 public interface MenuItemService {
+
+	MenuItem findById(UUID menuId);
 
 	@Transactional(readOnly = true)
 	Page<MenuItemResponseDto> getAllByStore(UUID storeId, boolean includeHidden, String keyword,

--- a/src/main/java/com/sparta/dingdong/domain/menu/service/MenuItemServiceImpl.java
+++ b/src/main/java/com/sparta/dingdong/domain/menu/service/MenuItemServiceImpl.java
@@ -39,6 +39,13 @@ public class MenuItemServiceImpl implements MenuItemService {
 	private final AuthService authService;
 	private final UserRepository userRepository;
 
+	@Override
+	@Transactional(readOnly = true)
+	public MenuItem findById(UUID menuId) {
+		return menuItemRepository.findById(menuId)
+			.orElseThrow(MenuItemNotFoundException::new);
+	}
+
 	@Transactional(readOnly = true)
 	@Override
 	public Page<MenuItemResponseDto> getAllByStore(UUID storeId, boolean includeHidden, String keyword,
@@ -108,8 +115,7 @@ public class MenuItemServiceImpl implements MenuItemService {
 	@Transactional(readOnly = true)
 	@Override
 	public MenuItemResponseDto getById(UUID menuId, UserAuth user) {
-		MenuItem menu = menuItemRepository.findById(menuId)
-			.orElseThrow(MenuItemNotFoundException::new);
+		MenuItem menu = findById(menuId);
 
 		authService.validateStoreOwnership(user, menu.getStore().getOwner().getId());
 		return map(menu);
@@ -117,8 +123,7 @@ public class MenuItemServiceImpl implements MenuItemService {
 
 	@Override
 	public MenuItemResponseDto update(UUID menuId, MenuItemRequestDto req, UserAuth user) {
-		MenuItem menu = menuItemRepository.findById(menuId)
-			.orElseThrow(MenuItemNotFoundException::new);
+		MenuItem menu = findById(menuId);
 		authService.validateStoreOwnership(user, menu.getStore().getOwner().getId());
 
 		User currentUser = userRepository.findById(user.getId())
@@ -143,8 +148,7 @@ public class MenuItemServiceImpl implements MenuItemService {
 
 	@Override
 	public void delete(UUID menuId, UserAuth user) {
-		MenuItem menu = menuItemRepository.findById(menuId)
-			.orElseThrow(MenuItemNotFoundException::new);
+		MenuItem menu = findById(menuId);
 
 		authService.validateStoreOwnership(user, menu.getStore().getOwner().getId());
 

--- a/src/main/java/com/sparta/dingdong/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/sparta/dingdong/domain/order/service/OrderServiceImpl.java
@@ -75,8 +75,7 @@ public class OrderServiceImpl implements OrderService {
 	@Transactional
 	public OrderResponseDto createOrder(UserAuth userAuth, CreateOrderRequestDto request) {
 		User user = userService.findByUser(userAuth);
-
-		Cart cart = cartService.findByCart(request.getCartId());
+		Cart cart = cartService.findByUserId(user.getId());
 
 		Store store = storeRepository.findById(cart.getStore().getId())
 			.orElseThrow(() -> new IllegalArgumentException("해당 매장을 찾을 수 없습니다."));
@@ -127,7 +126,7 @@ public class OrderServiceImpl implements OrderService {
 
 		orderRepository.save(order);
 
-		cartService.deleteCart(cart);
+		cartService.deleteCart(userAuth);
 
 		return OrderResponseDto.from(order);
 	}

--- a/src/test/java/com/sparta/dingdong/common/TestDataFactory.java
+++ b/src/test/java/com/sparta/dingdong/common/TestDataFactory.java
@@ -1,0 +1,165 @@
+package com.sparta.dingdong.common;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+import com.sparta.dingdong.common.entity.Dong;
+import com.sparta.dingdong.common.jwt.UserAuth;
+import com.sparta.dingdong.domain.cart.entity.Cart;
+import com.sparta.dingdong.domain.category.entity.StoreCategory;
+import com.sparta.dingdong.domain.menu.entity.MenuItem;
+import com.sparta.dingdong.domain.store.entity.Store;
+import com.sparta.dingdong.domain.store.entity.StoreDeliveryArea;
+import com.sparta.dingdong.domain.store.entity.enums.StoreStatus;
+import com.sparta.dingdong.domain.user.entity.User;
+import com.sparta.dingdong.domain.user.entity.enums.UserRole;
+
+public class TestDataFactory {
+
+	public static UserAuth createUserAuth(User user) {
+		return new UserAuth(user.getId(), user.getUserRole(), 1L);
+	}
+
+	// ===== Users =====
+	public static User createCustomer() {
+		return User.builder()
+			.id(1L)
+			.email("customer2@example.com")
+			.password("Customer123!")
+			.username("customerUser")
+			.nickname("김고객2")
+			.phone("010-1111-1111")
+			.userRole(UserRole.CUSTOMER)
+			.build();
+	}
+
+	public static User createOwner() {
+		return User.builder()
+			.id(2L)
+			.email("owner@example.com")
+			.password("Owner123!")
+			.username("ownerUser")
+			.nickname("박주인")
+			.phone("010-2222-2222")
+			.userRole(UserRole.OWNER)
+			.build();
+	}
+
+	// ===== StoreCategory =====
+	public static StoreCategory createStoreCategory() {
+		return StoreCategory.builder()
+			.id(UUID.fromString("20227a32-fa45-4d87-a972-27f32b475024"))
+			.name("한식")
+			.description("한식 전문점")
+			.imageUrl("https://image.url/korean.jpg")
+			.build();
+	}
+
+	// ===== Store =====
+	public static Store createStore(StoreCategory category, User owner) {
+		return Store.builder()
+			.id(UUID.fromString("246fdbcd-3258-4fd7-9353-38a4ac5ee2ff"))
+			.owner(owner)
+			.storeCategory(category)
+			.name("맛있는 치킨집")
+			.imageUrl("https://example.com/chicken.jpg")
+			.address("서울시 강남구 테헤란로 123")
+			.postalCode("06234")
+			.minOrderPrice(BigInteger.valueOf(20000))
+			.status(StoreStatus.OPEN)
+			.build();
+	}
+
+	public static Store createStore2(StoreCategory category, User owner) {
+		return Store.builder()
+			.id(UUID.fromString("5e1a8f73-7c89-4e4c-b2a5-1bfa6b3b7c91"))
+			.owner(owner)
+			.storeCategory(category)
+			.name("중식본점")
+			.imageUrl("https://example.com/sushi.jpg")
+			.address("서울시 강남구 테헤란로 124")
+			.postalCode("06235")
+			.minOrderPrice(BigInteger.valueOf(15000))
+			.status(StoreStatus.OPEN)
+			.build();
+	}
+
+	// ===== StoreDeliveryArea =====
+	public static StoreDeliveryArea createDeliveryArea(Store store, Dong dong) {
+		return StoreDeliveryArea.builder()
+			.id(UUID.fromString("b6fce01c-25c3-4f9e-9f64-874b5d29b1e2"))
+			.store(store)
+			.dong(dong)
+			.build();
+	}
+
+	// ===== MenuItems =====
+	public static MenuItem createKimchiStew(Store store) {
+		return MenuItem.builder()
+			.id(UUID.fromString("96e49a63-3f80-4360-83c6-721c1ffc4a06"))
+			.aiContent("국물이 진하고 깊은 김치찌개")
+			.isActive(true)
+			.isAiUsed(false)
+			.isDisplayed(true)
+			.isRecommended(false)
+			.isSoldout(false)
+			.name("김치찌개")
+			.price(BigInteger.valueOf(8000))
+			.store(store)
+			.build();
+	}
+
+	public static MenuItem createDoenjangStew(Store store) {
+		return MenuItem.builder()
+			.id(UUID.fromString("f88eef64-a84a-450b-a797-3c4d255e68bb"))
+			.aiContent("구수한 된장찌개")
+			.isActive(true)
+			.isAiUsed(false)
+			.isDisplayed(true)
+			.isRecommended(false)
+			.isSoldout(false)
+			.name("된장찌개")
+			.price(BigInteger.valueOf(7000))
+			.store(store)
+			.build();
+	}
+
+	public static MenuItem createJjajang(Store store) {
+		return MenuItem.builder()
+			.id(UUID.fromString("697e6efb-19b0-4566-a2cd-de11ffc23d33"))
+			.aiContent("달콤하고 진한 짜장면")
+			.isActive(true)
+			.isAiUsed(false)
+			.isDisplayed(true)
+			.isRecommended(true)
+			.isSoldout(false)
+			.name("짜장면")
+			.price(BigInteger.valueOf(6000))
+			.store(store)
+			.build();
+	}
+
+	public static MenuItem createJjamppong(Store store) {
+		return MenuItem.builder()
+			.id(UUID.fromString("e705721d-ec2f-4096-8e5b-cb12a64dd70c"))
+			.aiContent("얼큰하고 시원한 짬뽕")
+			.isActive(true)
+			.isAiUsed(false)
+			.isDisplayed(true)
+			.isRecommended(true)
+			.isSoldout(false)
+			.name("짬뽕")
+			.price(BigInteger.valueOf(8500))
+			.store(store)
+			.build();
+	}
+
+	// ===== Cart 생성 예시 =====
+	public static Cart createCart(User customer, Store store, MenuItem... items) {
+		Cart cart = Cart.of(customer, store);
+		for (MenuItem item : items) {
+			cart.addItem(item, 1); // quantity 1로 추가
+		}
+		return cart;
+	}
+}

--- a/src/test/java/com/sparta/dingdong/common/TestDataFactory.java
+++ b/src/test/java/com/sparta/dingdong/common/TestDataFactory.java
@@ -117,7 +117,7 @@ public class TestDataFactory {
 			.isAiUsed(false)
 			.isDisplayed(true)
 			.isRecommended(false)
-			.isSoldout(false)
+			.isSoldout(true)
 			.name("된장찌개")
 			.price(BigInteger.valueOf(7000))
 			.store(store)

--- a/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
@@ -43,10 +43,8 @@ class CartServiceImplTest {
 
 	@InjectMocks
 	CartServiceImpl cartService;
-
 	@Mock
 	CartRepository cartRepository;
-
 	@Mock
 	MenuItemService menuItemService;
 	@Mock
@@ -87,7 +85,7 @@ class CartServiceImplTest {
 	class GetCartTest {
 		@DisplayName("장바구니에 아이템 없으면 조회되지 않아 예외처리")
 		@Test
-		void getCart_exception() {
+		void getCart_noItems_exception() {
 			// given
 			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
 
@@ -101,9 +99,9 @@ class CartServiceImplTest {
 	@Nested
 	@DisplayName("장바구니 아이템 추가")
 	class AddItemToCartTest {
-		@DisplayName("장바구니가 없을 때 addItem을 호출하면 새 장바구니가 생성된다.")
+		@DisplayName("장바구니가 없을 때 addItem을 호출하면 새 장바구니 생성")
 		@Test
-		void addItem_whenCartNotExists_shouldCreateNewCart() {
+		void addItem_whenCartNotExists_createsCart() {
 			final int QTY_2 = 2;
 
 			//given
@@ -139,7 +137,7 @@ class CartServiceImplTest {
 
 		@DisplayName("품절된 메뉴 addItem 호출 시 예외처리")
 		@Test
-		void addItem_soldOut_menuItem() {
+		void addItem_soldOut_exception() {
 			// given
 			when(menuItemService.findById(doenjang.getId())).thenReturn(doenjang);
 
@@ -155,7 +153,7 @@ class CartServiceImplTest {
 		// 동일 메뉴 여러번 addItem 호출 시 수량 합산 확인
 		@DisplayName("동일 메뉴 여러번 addItem 호출 시 수량 합산")
 		@Test
-		void addItem_existing_menuItem() {
+		void addItem_existingMenu_increasesQuantity() {
 			// given
 			final int QTY_2 = 2;
 
@@ -194,7 +192,7 @@ class CartServiceImplTest {
 
 		@DisplayName("존재하지 않은 menuItem addItem 호출 시 예외처리")
 		@Test
-		void addItem_nonExisting_menuItem() {
+		void addItem_nonExistingMenu_exception() {
 			// given
 			final UUID nonExistingMenuItemId = UUID.randomUUID();
 
@@ -215,7 +213,7 @@ class CartServiceImplTest {
 
 		@DisplayName("장바구니에 다른 가게가 있으면 replace=false일 때 예외처리")
 		@Test
-		void addItem_replace_false() {
+		void addItem_conflict_replaceFalse_exception() {
 			final int QTY_2 = 2;
 
 			// given
@@ -242,7 +240,7 @@ class CartServiceImplTest {
 
 		@DisplayName("장바구니에 다른 가게가 있으면 replace=true일 때 기존 장바구니 교체하고 추가")
 		@Test
-		void addItem_replace_true() {
+		void addItem_conflict_replaceTrue_replacesAndAdds() {
 			final int QTY_2 = 2;
 
 			// given
@@ -317,7 +315,7 @@ class CartServiceImplTest {
 
 		@DisplayName("장바구니 아이템 수량 0으로 변경하면 예외처리")
 		@Test
-		void updateItemQuantity_exception() {
+		void updateItemQuantity_zero_exception() {
 			final int QTY_0 = 0;
 
 			//given
@@ -394,7 +392,7 @@ class CartServiceImplTest {
 
 		@DisplayName("장바구니에 담긴 마지막 아이템 삭제 시 장바구니도 함께 삭제")
 		@Test
-		void deleteItem_whenLastItem_thenDeleteCart() {
+		void deleteItem_lastItem_deletesCart() {
 			// given
 			Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang); // 1개 들어 있음
 			assignIdsToCartItems(existingCart);
@@ -417,7 +415,7 @@ class CartServiceImplTest {
 
 		@DisplayName("장바구니에 담긴 아이템이 아닌 경우 예외처리")
 		@Test
-		void deleteItem_whenUnknownItem_exception() {
+		void deleteItem_nonExistingMenu_exception() {
 			final UUID nonExistingMenuItemId = UUID.randomUUID();
 
 			// given
@@ -463,7 +461,7 @@ class CartServiceImplTest {
 
 		@DisplayName("빈 장바구니 삭제 예외처리")
 		@Test
-		void deleteCart_emptyCartException() {
+		void deleteCart_empty_exception() {
 			// given
 			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
 

--- a/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
@@ -9,12 +9,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sparta.dingdong.common.TestDataFactory;
-import com.sparta.dingdong.common.TestJasyptConfig;
 import com.sparta.dingdong.common.jwt.UserAuth;
 import com.sparta.dingdong.domain.cart.dto.request.AddCartItemRequestDto;
 import com.sparta.dingdong.domain.cart.dto.response.CartItemResponseDto;
@@ -31,18 +31,19 @@ import com.sparta.dingdong.domain.store.entity.Store;
 import com.sparta.dingdong.domain.user.entity.User;
 import com.sparta.dingdong.domain.user.service.UserService;
 
-@SpringBootTest(classes = {CartServiceImpl.class, TestJasyptConfig.class})
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CartService 테스트")
 class CartServiceImplTest {
 
-	@Autowired
-	CartService cartService;
+	@InjectMocks
+	CartServiceImpl cartService;
 
-	@MockBean
+	@Mock
 	CartRepository cartRepository;
 
-	@MockBean
+	@Mock
 	MenuItemService menuItemService;
-	@MockBean
+	@Mock
 	UserService userService;
 
 	private User customer;
@@ -73,42 +74,7 @@ class CartServiceImplTest {
 		userAuth = TestDataFactory.createUserAuth(customer);
 	}
 
-	@DisplayName("장바구니 있으면 조회")
-	@Test
-	void getCart_success() {
-		//given
-		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
-		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
-
-		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
-			.menuItemId(kimchi.getId())
-			.quantity(2)
-			.build();
-
-		when(cartRepository.save(any(Cart.class)))
-			.thenAnswer(invocation -> invocation.getArgument(0));
-
-		//when
-		CartResponseDto response = cartService.addItem(userAuth, request, false);
-
-		//then
-		assertNotNull(response);
-		assertEquals(store.getId(), response.getStoreId());
-		assertEquals(store.getName(), response.getStoreName());
-		assertEquals(1, response.getItems().size());
-
-		CartItemResponseDto itemResponse = response.getItems().get(0);
-		assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
-		assertEquals(2, itemResponse.getQuantity());
-
-		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(2));
-		assertEquals(expectedTotal, response.getTotalPrice());
-
-		verify(cartRepository, times(1)).findByUserId(customer.getId());
-		verify(userService, times(1)).findByUser(any(UserAuth.class));
-	}
-
-	@DisplayName("장바구니 없으면 예외처리")
+	@DisplayName("장바구니에 메뉴 담아둔거 없으면 조회되지 않아 예외처리")
 	@Test
 	void getCart_exception() {
 		// given
@@ -121,9 +87,48 @@ class CartServiceImplTest {
 		verify(cartRepository, times(1)).findByUserId(customer.getId());
 	}
 
+	@DisplayName("장바구니가 없을 때 addItem을 호출하면 새 장바구니가 생성된다.")
+	@Test
+	void addItem_whenCartNotExists_shouldCreateNewCart() {
+		final int QTY_2 = 2;
+
+		//given
+		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
+		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+			.menuItemId(kimchi.getId())
+			.quantity(2)
+			.build();
+
+		when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		//when
+		CartResponseDto response = cartService.addItem(userAuth, request, false);
+
+		//then
+		assertNotNull(response);
+		assertEquals(store.getId(), response.getStoreId());
+		assertEquals(store.getName(), response.getStoreName());
+		assertEquals(1, response.getItems().size());
+
+		CartItemResponseDto itemResponse = response.getItems().get(0);
+		assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
+		assertEquals(QTY_2, itemResponse.getQuantity());
+
+		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_2));
+		assertEquals(expectedTotal, response.getTotalPrice());
+
+		verify(cartRepository, times(1)).findByUserId(customer.getId());
+		verify(userService, times(1)).findByUser(any(UserAuth.class));
+		verify(menuItemService, times(1)).findById(kimchi.getId());
+	}
+
 	@DisplayName("장바구니에 다른 가게가 있으면 replace=false일 때 예외처리")
 	@Test
 	void addItem_replace_false() {
+		final int QTY_2 = 2;
+
 		// given
 		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
 		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
@@ -134,9 +139,8 @@ class CartServiceImplTest {
 
 		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
 			.menuItemId(kimchi.getId())
-			.quantity(2)
+			.quantity(QTY_2)
 			.build();
-		when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> inv.getArgument(0));
 
 		// when & then
 		assertThrows(CartStoreConflictException.class, () -> cartService.addItem(userAuth, request, false));
@@ -151,6 +155,8 @@ class CartServiceImplTest {
 	@DisplayName("장바구니에 다른 가게가 있으면 replace=true일 때 기존 장바구니 교체하고 추가")
 	@Test
 	void addItem_replace_true() {
+		final int QTY_2 = 2;
+
 		// given
 		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
 		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
@@ -159,13 +165,12 @@ class CartServiceImplTest {
 		Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang);
 
 		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
-
 		when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> inv.getArgument(0));
 
 		// store1 메뉴 장바구니에 추가
 		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
 			.menuItemId(kimchi.getId())
-			.quantity(2)
+			.quantity(QTY_2)
 			.build();
 
 		// when
@@ -179,9 +184,9 @@ class CartServiceImplTest {
 
 		CartItemResponseDto itemResponse = response.getItems().get(0);
 		assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
-		assertEquals(2, itemResponse.getQuantity());
+		assertEquals(QTY_2, itemResponse.getQuantity());
 
-		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(2));
+		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_2));
 		assertEquals(expectedTotal, response.getTotalPrice());
 
 		verify(cartRepository, times(1)).findByUserId(customer.getId());
@@ -191,23 +196,19 @@ class CartServiceImplTest {
 	@DisplayName("장바구니 메뉴 수량 변경 성공")
 	@Test
 	void updateItemQuantity_success() {
+		final int QTY_3 = 3;
+
 		//given
 		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
-		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
 
 		Cart existingCart = TestDataFactory.createCart(customer, store, kimchi);
 		existingCart.addItem(kimchi, 2);
 
-		when(cartRepository.findByUserId(customer.getId()))
-			.thenReturn(Optional.of(existingCart));
-
-		when(cartRepository.save(any(Cart.class)))
-			.thenAnswer(invocation -> invocation.getArgument(0));
-
-		int newQuantity = 3;
+		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
+		when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
 		// when
-		CartResponseDto response = cartService.updateItemQuantity(userAuth, kimchi.getId(), newQuantity);
+		CartResponseDto response = cartService.updateItemQuantity(userAuth, kimchi.getId(), QTY_3);
 
 		// then
 		assertNotNull(response);
@@ -216,37 +217,32 @@ class CartServiceImplTest {
 
 		CartItemResponseDto updatedItem = response.getItems().get(0);
 		assertEquals(kimchi.getId(), updatedItem.getMenuItemId());
-		assertEquals(newQuantity, updatedItem.getQuantity());
+		assertEquals(QTY_3, updatedItem.getQuantity());
 
-		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(newQuantity));
+		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_3));
 		assertEquals(expectedTotal, response.getTotalPrice());
 
 		verify(cartRepository, times(1)).findByUserId(customer.getId());
 		verify(cartRepository, times(1)).save(any(Cart.class));
 	}
 
-	@DisplayName("장바구니 메뉴 수량 0으로 변경 예외처리")
+	@DisplayName("장바구니 메뉴 수량 0으로 변경하면 예외처리")
 	@Test
 	void updateItemQuantity_exception() {
+		final int QTY_0 = 0;
+
 		//given
 		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
-		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
 
 		Cart existingCart = TestDataFactory.createCart(customer, store, kimchi);
 		existingCart.addItem(kimchi, 2);
 
-		when(cartRepository.findByUserId(customer.getId()))
-			.thenReturn(Optional.of(existingCart));
-
-		when(cartRepository.save(any(Cart.class)))
-			.thenAnswer(invocation -> invocation.getArgument(0));
-
-		int newQuantity = 0;
+		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
 
 		// when & then
 		assertThrows(
 			InvalidCartQuantityException.class,
-			() -> cartService.updateItemQuantity(userAuth, kimchi.getId(), newQuantity)
+			() -> cartService.updateItemQuantity(userAuth, kimchi.getId(), QTY_0)
 		);
 
 		verify(cartRepository, times(1)).findByUserId(customer.getId());

--- a/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
@@ -150,7 +150,6 @@ class CartServiceImplTest {
 			assertThrows(MenuItemSoldOutException.class, () -> cartService.addItem(userAuth, request, false));
 		}
 
-		// 동일 메뉴 여러번 addItem 호출 시 수량 합산 확인
 		@DisplayName("동일 메뉴 여러번 addItem 호출 시 수량 합산")
 		@Test
 		void addItem_existingMenu_increasesQuantity() {

--- a/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
@@ -1,0 +1,256 @@
+package com.sparta.dingdong.domain.cart.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.sparta.dingdong.common.TestDataFactory;
+import com.sparta.dingdong.common.TestJasyptConfig;
+import com.sparta.dingdong.common.jwt.UserAuth;
+import com.sparta.dingdong.domain.cart.dto.request.AddCartItemRequestDto;
+import com.sparta.dingdong.domain.cart.dto.response.CartItemResponseDto;
+import com.sparta.dingdong.domain.cart.dto.response.CartResponseDto;
+import com.sparta.dingdong.domain.cart.entity.Cart;
+import com.sparta.dingdong.domain.cart.exception.CartNotFoundException;
+import com.sparta.dingdong.domain.cart.exception.CartStoreConflictException;
+import com.sparta.dingdong.domain.cart.exception.InvalidCartQuantityException;
+import com.sparta.dingdong.domain.cart.repository.CartRepository;
+import com.sparta.dingdong.domain.category.entity.StoreCategory;
+import com.sparta.dingdong.domain.menu.entity.MenuItem;
+import com.sparta.dingdong.domain.menu.service.MenuItemService;
+import com.sparta.dingdong.domain.store.entity.Store;
+import com.sparta.dingdong.domain.user.entity.User;
+import com.sparta.dingdong.domain.user.service.UserService;
+
+@SpringBootTest(classes = {CartServiceImpl.class, TestJasyptConfig.class})
+class CartServiceImplTest {
+
+	@Autowired
+	CartService cartService;
+
+	@MockBean
+	CartRepository cartRepository;
+
+	@MockBean
+	MenuItemService menuItemService;
+	@MockBean
+	UserService userService;
+
+	private User customer;
+	private UserAuth userAuth;
+	private User owner;
+	private StoreCategory category;
+	private Store store;
+	private Store store2;
+	private MenuItem kimchi;
+	private MenuItem doenjang;
+	private MenuItem jjajang;
+	private MenuItem jjamppong;
+
+	@BeforeEach
+	void setUp() {
+		customer = TestDataFactory.createCustomer();
+		owner = TestDataFactory.createOwner();
+		category = TestDataFactory.createStoreCategory();
+		store = TestDataFactory.createStore(category, owner);
+		store2 = TestDataFactory.createStore2(category, owner);
+
+		kimchi = TestDataFactory.createKimchiStew(store);
+		doenjang = TestDataFactory.createDoenjangStew(store);
+
+		jjajang = TestDataFactory.createJjajang(store2);
+		jjamppong = TestDataFactory.createJjamppong(store2);
+
+		userAuth = TestDataFactory.createUserAuth(customer);
+	}
+
+	@DisplayName("장바구니 있으면 조회")
+	@Test
+	void getCart_success() {
+		//given
+		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
+		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+			.menuItemId(kimchi.getId())
+			.quantity(2)
+			.build();
+
+		when(cartRepository.save(any(Cart.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		//when
+		CartResponseDto response = cartService.addItem(userAuth, request, false);
+
+		//then
+		assertNotNull(response);
+		assertEquals(store.getId(), response.getStoreId());
+		assertEquals(store.getName(), response.getStoreName());
+		assertEquals(1, response.getItems().size());
+
+		CartItemResponseDto itemResponse = response.getItems().get(0);
+		assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
+		assertEquals(2, itemResponse.getQuantity());
+
+		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(2));
+		assertEquals(expectedTotal, response.getTotalPrice());
+
+		verify(cartRepository, times(1)).findByUserId(customer.getId());
+		verify(userService, times(1)).findByUser(any(UserAuth.class));
+	}
+
+	@DisplayName("장바구니 없으면 예외처리")
+	@Test
+	void getCart_exception() {
+		// given
+		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
+		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
+
+		// when & then
+		assertThrows(CartNotFoundException.class, () -> cartService.getCart(userAuth));
+
+		verify(cartRepository, times(1)).findByUserId(customer.getId());
+	}
+
+	@DisplayName("장바구니에 다른 가게가 있으면 replace=false일 때 예외처리")
+	@Test
+	void addItem_replace_false() {
+		// given
+		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
+		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+		Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang);
+
+		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
+
+		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+			.menuItemId(kimchi.getId())
+			.quantity(2)
+			.build();
+		when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		// when & then
+		assertThrows(CartStoreConflictException.class, () -> cartService.addItem(userAuth, request, false));
+
+		// 기존 장바구니를 조회했는지 확인
+		verify(cartRepository, times(1)).findByUserId(customer.getId());
+		verify(menuItemService, times(1)).findById(kimchi.getId());
+
+		verify(cartRepository, never()).save(any(Cart.class));
+	}
+
+	@DisplayName("장바구니에 다른 가게가 있으면 replace=true일 때 기존 장바구니 교체하고 추가")
+	@Test
+	void addItem_replace_true() {
+		// given
+		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
+		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+		// store2 메뉴 장바구니에 추가
+		Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang);
+
+		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
+
+		when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		// store1 메뉴 장바구니에 추가
+		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+			.menuItemId(kimchi.getId())
+			.quantity(2)
+			.build();
+
+		// when
+		CartResponseDto response = cartService.addItem(userAuth, request, true);
+
+		// then
+		assertNotNull(response);
+		assertEquals(kimchi.getStore().getId(), response.getStoreId());
+		assertEquals(kimchi.getStore().getName(), response.getStoreName());
+		assertEquals(1, response.getItems().size());
+
+		CartItemResponseDto itemResponse = response.getItems().get(0);
+		assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
+		assertEquals(2, itemResponse.getQuantity());
+
+		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(2));
+		assertEquals(expectedTotal, response.getTotalPrice());
+
+		verify(cartRepository, times(1)).findByUserId(customer.getId());
+		verify(userService, times(1)).findByUser(any(UserAuth.class));
+	}
+
+	@DisplayName("장바구니 메뉴 수량 변경 성공")
+	@Test
+	void updateItemQuantity_success() {
+		//given
+		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
+		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+		Cart existingCart = TestDataFactory.createCart(customer, store, kimchi);
+		existingCart.addItem(kimchi, 2);
+
+		when(cartRepository.findByUserId(customer.getId()))
+			.thenReturn(Optional.of(existingCart));
+
+		when(cartRepository.save(any(Cart.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		int newQuantity = 3;
+
+		// when
+		CartResponseDto response = cartService.updateItemQuantity(userAuth, kimchi.getId(), newQuantity);
+
+		// then
+		assertNotNull(response);
+		assertEquals(store.getId(), response.getStoreId());
+		assertEquals(1, response.getItems().size());
+
+		CartItemResponseDto updatedItem = response.getItems().get(0);
+		assertEquals(kimchi.getId(), updatedItem.getMenuItemId());
+		assertEquals(newQuantity, updatedItem.getQuantity());
+
+		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(newQuantity));
+		assertEquals(expectedTotal, response.getTotalPrice());
+
+		verify(cartRepository, times(1)).findByUserId(customer.getId());
+		verify(cartRepository, times(1)).save(any(Cart.class));
+	}
+
+	@DisplayName("장바구니 메뉴 수량 0으로 변경 예외처리")
+	@Test
+	void updateItemQuantity_exception() {
+		//given
+		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
+		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+		Cart existingCart = TestDataFactory.createCart(customer, store, kimchi);
+		existingCart.addItem(kimchi, 2);
+
+		when(cartRepository.findByUserId(customer.getId()))
+			.thenReturn(Optional.of(existingCart));
+
+		when(cartRepository.save(any(Cart.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		int newQuantity = 0;
+
+		// when & then
+		assertThrows(
+			InvalidCartQuantityException.class,
+			() -> cartService.updateItemQuantity(userAuth, kimchi.getId(), newQuantity)
+		);
+
+		verify(cartRepository, times(1)).findByUserId(customer.getId());
+		verify(cartRepository, never()).save(any(Cart.class));
+
+	}
+}

--- a/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -79,248 +80,260 @@ class CartServiceImplTest {
 		when(userService.findByUser(any(UserAuth.class))).thenReturn(customer);
 	}
 
-	@DisplayName("장바구니에 메뉴 담아둔거 없으면 조회되지 않아 예외처리")
-	@Test
-	void getCart_exception() {
-		// given
-		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
+	@Nested
+	@DisplayName("장바구니 조회")
+	class GetCartTest {
+		@DisplayName("장바구니에 메뉴 담아둔거 없으면 조회되지 않아 예외처리")
+		@Test
+		void getCart_exception() {
+			// given
+			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
 
-		// when & then
-		assertThrows(CartNotFoundException.class, () -> cartService.getCart(userAuth));
+			// when & then
+			assertThrows(CartNotFoundException.class, () -> cartService.getCart(userAuth));
 
-		verify(cartRepository, times(1)).findByUserId(customer.getId());
+			verify(cartRepository, times(1)).findByUserId(customer.getId());
+		}
 	}
 
-	@DisplayName("장바구니가 없을 때 addItem을 호출하면 새 장바구니가 생성된다.")
-	@Test
-	void addItem_whenCartNotExists_shouldCreateNewCart() {
-		final int QTY_2 = 2;
+	@Nested
+	@DisplayName("장바구니 아이템 추가")
+	class AddItemToCartTest {
+		@DisplayName("장바구니가 없을 때 addItem을 호출하면 새 장바구니가 생성된다.")
+		@Test
+		void addItem_whenCartNotExists_shouldCreateNewCart() {
+			final int QTY_2 = 2;
 
-		//given
-		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+			//given
+			when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
 
-		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
-			.menuItemId(kimchi.getId())
-			.quantity(2)
-			.build();
+			AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+				.menuItemId(kimchi.getId())
+				.quantity(2)
+				.build();
 
-		when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
+			when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-		//when
-		CartResponseDto response = cartService.addItem(userAuth, request, false);
+			//when
+			CartResponseDto response = cartService.addItem(userAuth, request, false);
 
-		//then
-		assertNotNull(response);
-		assertEquals(store.getId(), response.getStoreId());
-		assertEquals(store.getName(), response.getStoreName());
-		assertEquals(1, response.getItems().size());
+			//then
+			assertNotNull(response);
+			assertEquals(store.getId(), response.getStoreId());
+			assertEquals(store.getName(), response.getStoreName());
+			assertEquals(1, response.getItems().size());
 
-		CartItemResponseDto itemResponse = response.getItems().get(0);
-		assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
-		assertEquals(QTY_2, itemResponse.getQuantity());
+			CartItemResponseDto itemResponse = response.getItems().get(0);
+			assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
+			assertEquals(QTY_2, itemResponse.getQuantity());
 
-		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_2));
-		assertEquals(expectedTotal, response.getTotalPrice());
+			BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_2));
+			assertEquals(expectedTotal, response.getTotalPrice());
 
-		verify(cartRepository, times(1)).findByUserId(customer.getId());
-		verify(userService, times(1)).findByUser(any(UserAuth.class));
-		verify(menuItemService, times(1)).findById(kimchi.getId());
+			verify(cartRepository, times(1)).findByUserId(customer.getId());
+			verify(userService, times(1)).findByUser(any(UserAuth.class));
+			verify(menuItemService, times(1)).findById(kimchi.getId());
+		}
+
+		@DisplayName("품절된 메뉴 addItem 호출 시 예외처리")
+		@Test
+		void addItem_soldOut_menuItem() {
+			// given
+			when(menuItemService.findById(doenjang.getId())).thenReturn(doenjang);
+
+			AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+				.menuItemId(doenjang.getId())
+				.quantity(2)
+				.build();
+
+			// when & then
+			assertThrows(MenuItemSoldOutException.class, () -> cartService.addItem(userAuth, request, false));
+		}
+
+		// 동일 메뉴 여러번 addItem 호출 시 수량 합산 확인
+		@DisplayName("동일 메뉴 여러번 addItem 호출 시 수량 합산")
+		@Test
+		void addItem_existing_menuItem() {
+			// given
+			final int QTY_2 = 2;
+
+			when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+			Cart existingCart = TestDataFactory.createCart(customer, store, kimchi); // 1개 들어 있음
+
+			when(cartRepository.findByUserId(eq(customer.getId()))).thenReturn(Optional.of(existingCart));
+			when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+			AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+				.menuItemId(kimchi.getId())
+				.quantity(QTY_2) // 2개 추가
+				.build();
+
+			// when
+			CartResponseDto response = cartService.addItem(userAuth, request, false);
+
+			// then
+			assertNotNull(response);
+			assertEquals(store.getId(), response.getStoreId());
+			assertEquals(store.getName(), response.getStoreName());
+			assertEquals(1, response.getItems().size());
+
+			CartItemResponseDto itemResponse = response.getItems().get(0);
+			assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
+			assertEquals(QTY_2 + 1, itemResponse.getQuantity());
+
+			BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_2 + 1));
+			assertEquals(expectedTotal, response.getTotalPrice());
+
+			verify(userService, times(1)).findByUser(any(UserAuth.class));
+			verify(menuItemService, times(1)).findById(kimchi.getId());
+			verify(cartRepository, times(1)).findByUserId(customer.getId());
+		}
+
+		@DisplayName("존재하지 않은 menuItem addItem 호출 시 예외처리")
+		@Test
+		void addItem_nonExisting_menuItem() {
+			// given
+			final UUID nonExistingMenuItemId = UUID.randomUUID();
+
+			when(menuItemService.findById(nonExistingMenuItemId)).thenThrow(new MenuItemNotFoundException());
+
+			AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+				.menuItemId(nonExistingMenuItemId)
+				.quantity(1)
+				.build();
+
+			// when & then
+			assertThrows(MenuItemNotFoundException.class, () -> cartService.addItem(userAuth, request, false));
+
+			verify(userService, times(1)).findByUser(any(UserAuth.class));
+			verify(menuItemService, times(1)).findById(nonExistingMenuItemId);
+			verify(cartRepository, never()).save(any(Cart.class));
+		}
+
+		@DisplayName("장바구니에 다른 가게가 있으면 replace=false일 때 예외처리")
+		@Test
+		void addItem_replace_false() {
+			final int QTY_2 = 2;
+
+			// given
+			when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+			Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang);
+
+			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
+
+			AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+				.menuItemId(kimchi.getId())
+				.quantity(QTY_2)
+				.build();
+
+			// when & then
+			assertThrows(CartStoreConflictException.class, () -> cartService.addItem(userAuth, request, false));
+
+			// 기존 장바구니를 조회했는지 확인
+			verify(cartRepository, times(1)).findByUserId(customer.getId());
+			verify(menuItemService, times(1)).findById(kimchi.getId());
+
+			verify(cartRepository, never()).save(any(Cart.class));
+		}
+
+		@DisplayName("장바구니에 다른 가게가 있으면 replace=true일 때 기존 장바구니 교체하고 추가")
+		@Test
+		void addItem_replace_true() {
+			final int QTY_2 = 2;
+
+			// given
+			when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+
+			// store2 메뉴 장바구니에 추가
+			Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang);
+
+			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
+			when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> inv.getArgument(0));
+
+			// store1 메뉴 장바구니에 추가
+			AddCartItemRequestDto request = AddCartItemRequestDto.builder()
+				.menuItemId(kimchi.getId())
+				.quantity(QTY_2)
+				.build();
+
+			// when
+			CartResponseDto response = cartService.addItem(userAuth, request, true);
+
+			// then
+			assertNotNull(response);
+			assertEquals(kimchi.getStore().getId(), response.getStoreId());
+			assertEquals(kimchi.getStore().getName(), response.getStoreName());
+			assertEquals(1, response.getItems().size());
+
+			CartItemResponseDto itemResponse = response.getItems().get(0);
+			assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
+			assertEquals(QTY_2, itemResponse.getQuantity());
+
+			BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_2));
+			assertEquals(expectedTotal, response.getTotalPrice());
+
+			verify(cartRepository, times(1)).findByUserId(customer.getId());
+			verify(userService, times(1)).findByUser(any(UserAuth.class));
+		}
 	}
 
-	@DisplayName("품절된 메뉴 addItem 호출 시 예외처리")
-	@Test
-	void addItem_soldOut_menuItem() {
-		// given
-		when(menuItemService.findById(doenjang.getId())).thenReturn(doenjang);
+	@Nested
+	@DisplayName("장바구니 아이템 수량 변경")
+	class updateItemQuantity {
+		@DisplayName("장바구니 메뉴 수량 변경 성공")
+		@Test
+		void updateItemQuantity_success() {
+			final int QTY_3 = 3;
 
-		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
-			.menuItemId(doenjang.getId())
-			.quantity(2)
-			.build();
+			//given
+			Cart existingCart = TestDataFactory.createCart(customer, store, kimchi);
+			existingCart.addItem(kimchi, 2);
 
-		// when & then
-		assertThrows(MenuItemSoldOutException.class, () -> cartService.addItem(userAuth, request, false));
-	}
+			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
+			when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-	// 동일 메뉴 여러번 addItem 호출 시 수량 합산 확인
-	@DisplayName("동일 메뉴 여러번 addItem 호출 시 수량 합산")
-	@Test
-	void addItem_existing_menuItem() {
-		// given
-		final int QTY_2 = 2;
+			// when
+			CartResponseDto response = cartService.updateItemQuantity(userAuth, kimchi.getId(), QTY_3);
 
-		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
+			// then
+			assertNotNull(response);
+			assertEquals(store.getId(), response.getStoreId());
+			assertEquals(1, response.getItems().size());
 
-		Cart existingCart = TestDataFactory.createCart(customer, store, kimchi); // 1개 들어 있음
+			CartItemResponseDto updatedItem = response.getItems().get(0);
+			assertEquals(kimchi.getId(), updatedItem.getMenuItemId());
+			assertEquals(QTY_3, updatedItem.getQuantity());
 
-		when(cartRepository.findByUserId(eq(customer.getId()))).thenReturn(Optional.of(existingCart));
-		when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
+			BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_3));
+			assertEquals(expectedTotal, response.getTotalPrice());
 
-		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
-			.menuItemId(kimchi.getId())
-			.quantity(QTY_2) // 2개 추가
-			.build();
+			verify(cartRepository, times(1)).findByUserId(customer.getId());
+			verify(cartRepository, times(1)).save(any(Cart.class));
+		}
 
-		// when
-		CartResponseDto response = cartService.addItem(userAuth, request, false);
+		@DisplayName("장바구니 메뉴 수량 0으로 변경하면 예외처리")
+		@Test
+		void updateItemQuantity_exception() {
+			final int QTY_0 = 0;
 
-		// then
-		assertNotNull(response);
-		assertEquals(store.getId(), response.getStoreId());
-		assertEquals(store.getName(), response.getStoreName());
-		assertEquals(1, response.getItems().size());
+			//given
+			Cart existingCart = TestDataFactory.createCart(customer, store, kimchi);
+			existingCart.addItem(kimchi, 2);
 
-		CartItemResponseDto itemResponse = response.getItems().get(0);
-		assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
-		assertEquals(QTY_2 + 1, itemResponse.getQuantity());
+			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
 
-		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_2 + 1));
-		assertEquals(expectedTotal, response.getTotalPrice());
+			// when & then
+			assertThrows(
+				InvalidCartQuantityException.class,
+				() -> cartService.updateItemQuantity(userAuth, kimchi.getId(), QTY_0)
+			);
 
-		verify(userService, times(1)).findByUser(any(UserAuth.class));
-		verify(menuItemService, times(1)).findById(kimchi.getId());
-		verify(cartRepository, times(1)).findByUserId(customer.getId());
-	}
+			verify(cartRepository, times(1)).findByUserId(customer.getId());
+			verify(cartRepository, never()).save(any(Cart.class));
 
-	@DisplayName("존재하지 않은 menuItem addItem 호출 시 예외처리")
-	@Test
-	void addItem_nonExisting_menuItem() {
-		// given
-		final UUID nonExistingMenuItemId = UUID.randomUUID();
-
-		when(menuItemService.findById(nonExistingMenuItemId)).thenThrow(new MenuItemNotFoundException());
-
-		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
-			.menuItemId(nonExistingMenuItemId)
-			.quantity(1)
-			.build();
-
-		// when & then
-		assertThrows(MenuItemNotFoundException.class, () -> cartService.addItem(userAuth, request, false));
-
-		verify(userService, times(1)).findByUser(any(UserAuth.class));
-		verify(menuItemService, times(1)).findById(nonExistingMenuItemId);
-		verify(cartRepository, never()).save(any(Cart.class));
-	}
-
-	@DisplayName("장바구니에 다른 가게가 있으면 replace=false일 때 예외처리")
-	@Test
-	void addItem_replace_false() {
-		final int QTY_2 = 2;
-
-		// given
-		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
-
-		Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang);
-
-		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
-
-		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
-			.menuItemId(kimchi.getId())
-			.quantity(QTY_2)
-			.build();
-
-		// when & then
-		assertThrows(CartStoreConflictException.class, () -> cartService.addItem(userAuth, request, false));
-
-		// 기존 장바구니를 조회했는지 확인
-		verify(cartRepository, times(1)).findByUserId(customer.getId());
-		verify(menuItemService, times(1)).findById(kimchi.getId());
-
-		verify(cartRepository, never()).save(any(Cart.class));
-	}
-
-	@DisplayName("장바구니에 다른 가게가 있으면 replace=true일 때 기존 장바구니 교체하고 추가")
-	@Test
-	void addItem_replace_true() {
-		final int QTY_2 = 2;
-
-		// given
-		when(menuItemService.findById(kimchi.getId())).thenReturn(kimchi);
-
-		// store2 메뉴 장바구니에 추가
-		Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang);
-
-		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
-		when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> inv.getArgument(0));
-
-		// store1 메뉴 장바구니에 추가
-		AddCartItemRequestDto request = AddCartItemRequestDto.builder()
-			.menuItemId(kimchi.getId())
-			.quantity(QTY_2)
-			.build();
-
-		// when
-		CartResponseDto response = cartService.addItem(userAuth, request, true);
-
-		// then
-		assertNotNull(response);
-		assertEquals(kimchi.getStore().getId(), response.getStoreId());
-		assertEquals(kimchi.getStore().getName(), response.getStoreName());
-		assertEquals(1, response.getItems().size());
-
-		CartItemResponseDto itemResponse = response.getItems().get(0);
-		assertEquals(kimchi.getId(), itemResponse.getMenuItemId());
-		assertEquals(QTY_2, itemResponse.getQuantity());
-
-		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_2));
-		assertEquals(expectedTotal, response.getTotalPrice());
-
-		verify(cartRepository, times(1)).findByUserId(customer.getId());
-		verify(userService, times(1)).findByUser(any(UserAuth.class));
-	}
-
-	@DisplayName("장바구니 메뉴 수량 변경 성공")
-	@Test
-	void updateItemQuantity_success() {
-		final int QTY_3 = 3;
-
-		//given
-		Cart existingCart = TestDataFactory.createCart(customer, store, kimchi);
-		existingCart.addItem(kimchi, 2);
-
-		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
-		when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-		// when
-		CartResponseDto response = cartService.updateItemQuantity(userAuth, kimchi.getId(), QTY_3);
-
-		// then
-		assertNotNull(response);
-		assertEquals(store.getId(), response.getStoreId());
-		assertEquals(1, response.getItems().size());
-
-		CartItemResponseDto updatedItem = response.getItems().get(0);
-		assertEquals(kimchi.getId(), updatedItem.getMenuItemId());
-		assertEquals(QTY_3, updatedItem.getQuantity());
-
-		BigInteger expectedTotal = kimchi.getPrice().multiply(BigInteger.valueOf(QTY_3));
-		assertEquals(expectedTotal, response.getTotalPrice());
-
-		verify(cartRepository, times(1)).findByUserId(customer.getId());
-		verify(cartRepository, times(1)).save(any(Cart.class));
-	}
-
-	@DisplayName("장바구니 메뉴 수량 0으로 변경하면 예외처리")
-	@Test
-	void updateItemQuantity_exception() {
-		final int QTY_0 = 0;
-
-		//given
-		Cart existingCart = TestDataFactory.createCart(customer, store, kimchi);
-		existingCart.addItem(kimchi, 2);
-
-		when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingCart));
-
-		// when & then
-		assertThrows(
-			InvalidCartQuantityException.class,
-			() -> cartService.updateItemQuantity(userAuth, kimchi.getId(), QTY_0)
-		);
-
-		verify(cartRepository, times(1)).findByUserId(customer.getId());
-		verify(cartRepository, never()).save(any(Cart.class));
-
+		}
 	}
 
 	// 장바구니에 담긴 메뉴 삭제 - 성공
@@ -328,23 +341,27 @@ class CartServiceImplTest {
 	// 장바구니에 담긴 메뉴가 아닌 경우 예외처리
 
 	// 장바구니 삭제
-	@DisplayName("장바구니 삭제 성공")
-	@Test
-	void deleteCart_success() {
-		// given
-		Cart existingCart = TestDataFactory.createCart(customer, store, kimchi); // 1개 들어 있음
+	@Nested
+	@DisplayName("장바구니 삭제")
+	class deleteCart {
+		@DisplayName("장바구니 삭제 성공")
+		@Test
+		void deleteCart_success() {
+			// given
+			Cart existingCart = TestDataFactory.createCart(customer, store, kimchi); // 1개 들어 있음
 
-		when(cartRepository.findByUserId(eq(customer.getId()))).thenReturn(Optional.of(existingCart));
+			when(cartRepository.findByUserId(eq(customer.getId()))).thenReturn(Optional.of(existingCart));
 
-		doAnswer(invocation -> {
-			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
-			return null;
-		}).when(cartRepository).delete(any(Cart.class));
+			doAnswer(invocation -> {
+				when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
+				return null;
+			}).when(cartRepository).delete(any(Cart.class));
 
-		// when
-		cartService.deleteCart(userAuth);
+			// when
+			cartService.deleteCart(userAuth);
 
-		// then
-		assertThrows(CartNotFoundException.class, () -> cartService.getCart(userAuth));
+			// then
+			assertThrows(CartNotFoundException.class, () -> cartService.getCart(userAuth));
+		}
 	}
 }

--- a/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/sparta/dingdong/domain/cart/service/CartServiceImplTest.java
@@ -3,6 +3,7 @@ package com.sparta.dingdong.domain.cart.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,6 +23,7 @@ import com.sparta.dingdong.domain.cart.dto.request.AddCartItemRequestDto;
 import com.sparta.dingdong.domain.cart.dto.response.CartItemResponseDto;
 import com.sparta.dingdong.domain.cart.dto.response.CartResponseDto;
 import com.sparta.dingdong.domain.cart.entity.Cart;
+import com.sparta.dingdong.domain.cart.exception.CartItemNotFoundException;
 import com.sparta.dingdong.domain.cart.exception.CartNotFoundException;
 import com.sparta.dingdong.domain.cart.exception.CartStoreConflictException;
 import com.sparta.dingdong.domain.cart.exception.InvalidCartQuantityException;
@@ -83,7 +85,7 @@ class CartServiceImplTest {
 	@Nested
 	@DisplayName("장바구니 조회")
 	class GetCartTest {
-		@DisplayName("장바구니에 메뉴 담아둔거 없으면 조회되지 않아 예외처리")
+		@DisplayName("장바구니에 아이템 없으면 조회되지 않아 예외처리")
 		@Test
 		void getCart_exception() {
 			// given
@@ -282,7 +284,7 @@ class CartServiceImplTest {
 	@Nested
 	@DisplayName("장바구니 아이템 수량 변경")
 	class updateItemQuantity {
-		@DisplayName("장바구니 메뉴 수량 변경 성공")
+		@DisplayName("장바구니 아이템 수량 변경 성공")
 		@Test
 		void updateItemQuantity_success() {
 			final int QTY_3 = 3;
@@ -313,7 +315,7 @@ class CartServiceImplTest {
 			verify(cartRepository, times(1)).save(any(Cart.class));
 		}
 
-		@DisplayName("장바구니 메뉴 수량 0으로 변경하면 예외처리")
+		@DisplayName("장바구니 아이템 수량 0으로 변경하면 예외처리")
 		@Test
 		void updateItemQuantity_exception() {
 			final int QTY_0 = 0;
@@ -336,9 +338,102 @@ class CartServiceImplTest {
 		}
 	}
 
-	// 장바구니에 담긴 메뉴 삭제 - 성공
-	// 장바구니에 담긴 마지막 메뉴 삭제 시 장바구니도 함께 삭제
-	// 장바구니에 담긴 메뉴가 아닌 경우 예외처리
+	@Nested
+	@DisplayName("장바구니 아이템 삭제")
+	class deleteItem {
+		// cart에 있는 모든 cartItem에 randomUUID() 채워줌
+		private void assignIdsToCartItems(Cart cart) {
+			cart.getItems().forEach(item -> {
+				if (item.getId() == null) {
+					try {
+						Field idField = item.getClass().getDeclaredField("id");
+						idField.setAccessible(true);
+						idField.set(item, UUID.randomUUID());
+					} catch (NoSuchFieldException | IllegalAccessException e) {
+						throw new RuntimeException(e);
+					}
+				}
+			});
+		}
+
+		@DisplayName("장바구니 아이템 삭제 성공")
+		@Test
+		void deleteItem_success() {
+			// given
+			Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang, jjamppong); // 1개 들어 있음
+			assignIdsToCartItems(existingCart);
+
+			when(cartRepository.findByUserId(eq(customer.getId()))).thenReturn(Optional.of(existingCart));
+
+			when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> {
+				Cart c = inv.getArgument(0);
+				assignIdsToCartItems(c);
+				return c;
+			});
+
+			// when
+			cartService.deleteItem(userAuth, jjajang.getId());
+
+			// then
+			CartResponseDto response = cartService.getCart(userAuth);
+
+			assertNotNull(response);
+			assertEquals(store2.getId(), response.getStoreId());
+			assertEquals(1, response.getItems().size());
+
+			CartItemResponseDto updatedItem = response.getItems().get(0);
+			assertEquals(jjamppong.getId(), updatedItem.getMenuItemId());
+			assertEquals(1, updatedItem.getQuantity());
+
+			BigInteger expectedTotal = jjamppong.getPrice().multiply(BigInteger.valueOf(1));
+			assertEquals(expectedTotal, response.getTotalPrice());
+
+			verify(cartRepository, times(2)).findByUserId(customer.getId());
+			verify(cartRepository, times(1)).save(any(Cart.class));
+		}
+
+		@DisplayName("장바구니에 담긴 마지막 아이템 삭제 시 장바구니도 함께 삭제")
+		@Test
+		void deleteItem_whenLastItem_thenDeleteCart() {
+			// given
+			Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang); // 1개 들어 있음
+			assignIdsToCartItems(existingCart);
+
+			when(cartRepository.findByUserId(eq(customer.getId()))).thenReturn(Optional.of(existingCart));
+
+			doAnswer(invocation -> {
+				when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
+				return null;
+			}).when(cartRepository).delete(any(Cart.class));
+
+			// when
+			cartService.deleteItem(userAuth, jjajang.getId());
+
+			// then
+			assertThrows(CartNotFoundException.class, () -> cartService.getCart(userAuth));
+
+			verify(cartRepository, times(1)).delete(any(Cart.class));
+		}
+
+		@DisplayName("장바구니에 담긴 아이템이 아닌 경우 예외처리")
+		@Test
+		void deleteItem_whenUnknownItem_exception() {
+			final UUID nonExistingMenuItemId = UUID.randomUUID();
+
+			// given
+			Cart existingCart = TestDataFactory.createCart(customer, store2, jjajang); // 1개 들어 있음
+			assignIdsToCartItems(existingCart);
+
+			when(cartRepository.findByUserId(eq(customer.getId()))).thenReturn(Optional.of(existingCart));
+
+			// when & then
+			assertThrows(CartItemNotFoundException.class,
+				() -> cartService.deleteItem(userAuth, nonExistingMenuItemId));
+
+			verify(cartRepository, never()).save(any(Cart.class));
+			verify(cartRepository, never()).delete(any(Cart.class));
+		}
+	}
 
 	// 장바구니 삭제
 	@Nested
@@ -362,6 +457,20 @@ class CartServiceImplTest {
 
 			// then
 			assertThrows(CartNotFoundException.class, () -> cartService.getCart(userAuth));
+
+			verify(cartRepository, times(1)).delete(any(Cart.class));
+		}
+
+		@DisplayName("빈 장바구니 삭제 예외처리")
+		@Test
+		void deleteCart_emptyCartException() {
+			// given
+			when(cartRepository.findByUserId(customer.getId())).thenReturn(Optional.empty());
+
+			// when & then
+			assertThrows(CartNotFoundException.class, () -> cartService.deleteCart(userAuth));
+
+			verify(cartRepository, never()).delete(any(Cart.class));
 		}
 	}
 }


### PR DESCRIPTION
## 🔗 Issue 번호
- close #87 

## 🛠 작업 내역
- [x] cartId로 Cart 찾는 함수 -> userId로 Cart 찾도록
- [x] CartItem 조회하는 함수 따로 분리
- [x] addItem() 역할 Cart entity에 부여
- [x] CartServiceImpl 함수 네이밍 수정 

## 🔄 변경 사항
- Order에서 Cart를 찾을 때 userId로 찾게 함
- MenuItemService에서 MenuItem 조회하는 findById() 함수 따로 분리함

## ✨ 새로운 기능
**공통 객체 생성**
- customer, owner, storeCategory, store, menuItem ... 생성하는 코드 TestDataFactory에 작성했습니다. 활용해주세요!


**테스트코드 작성**
- 장바구니 조회
  - 장바구니에 아이템 없으면 조회되지 않아 예외처리
- 장바구니 아이템 추가
  - 장바구니가 없을 때 addItem을 호출하면 새 장바구니 생성
  - 품절된 메뉴 addItem 호출 시 예외처리
  - 동일 메뉴 여러번 addItem 호출 시 수량 합산
  - 존재하지 않은 menuItem addItem 호출 시 예외처리
  - 장바구니에 다른 가게가 있으면 replace=false일 때 예외처리
  - 장바구니에 다른 가게가 있으면 replace=true일 때 기존 장바구니 교체하고 추가
- 장바구니 아이템 수량 변경
  - 장바구니 아이템 수량 변경 성공
  - 장바구니 아이템 수량 0으로 변경하면 예외처리
- 장바구니 아이템 삭제
  - 장바구니 아이템 삭제 성공
  - 장바구니에 담긴 마지막 아이템 삭제 시 장바구니도 함께 삭제
  - 장바구니에 담긴 아이템이 아닌 경우 예외처리
- 장바구니 삭제
  - 장바구니 삭제 성공
  - 빈 장바구니 삭제 예외처리


## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

